### PR TITLE
Send token and query-distance

### DIFF
--- a/UNTrace/Widget.js
+++ b/UNTrace/Widget.js
@@ -220,7 +220,7 @@ function(declare,
       query.outSpatialReference = { wkid: 102100 };
       query.returnGeometry = true;
       query.outFields = [ "*" ];
-      query.distance = 2;
+      query.distance = 0.2;// previous 2 returned too much features
       query.geometry = event;
       fl.queryFeatures(query).then(lang.hitch(this, function(hitResults){
           console.log(hitResults.features);  // prints the array of features to the console

--- a/UNTrace/setting/Setting.js
+++ b/UNTrace/setting/Setting.js
@@ -122,6 +122,7 @@ function(declare, BaseWidgetSetting, _TemplatedMixin, on, domConstruct, query, l
         on(this.portal, "load", lang.hitch(this, function() {
           var currUser = cred.getUser().username;
           var params = {
+            token: this.token,
             q:'owner:' + currUser,
             num:100
           };


### PR DESCRIPTION
2 changes:
1: Send token when searching items of owner to return non-public items.
2: Search distance changed, previous 2 returned too much features. Nicer would be to make it configurable depending on TraceGroup. In my case a needed to select a transformer in a small SubStation, returning 50+ assets in the substation.